### PR TITLE
[improve][settings] Clarify MIDI control names

### DIFF
--- a/ksem_transformer/models/settings/custom_bank.py
+++ b/ksem_transformer/models/settings/custom_bank.py
@@ -12,20 +12,20 @@ midi_control_to_ksem_custom_bank_selection = bidict(
     {
         "m01_modulation": 1,
         "m02_breath": 2,
-        "m04_foot": 3,
-        "m05_portamento": 4,
+        "m04_foot_pedal": 3,
+        "m05_portamento_time": 4,
         "m07_volume": 5,
         "m10_pan": 6,
         "m11_expression": 7,
-        "m64_hold": 8,
-        "m65_portamento": 9,
-        "m66_sostenuto": 10,
-        "m67_soft": 11,
-        "m68_legato": 12,
+        "m64_hold_pedal": 8,
+        "m65_portamento_on_off": 9,
+        "m66_sostenuto_pedal": 10,
+        "m67_soft_pedal": 11,
+        "m68_legato_pedal": 12,
         "m71_resonance": 13,
-        "m74_frequency": 14,
-        "m91_reverb": 15,
-        "m93_chorus": 16,
+        "m74_frequency_cutoff": 14,
+        "m91_reverb_level": 15,
+        "m93_chorus_level": 16,
         "custom_01": 17,
         "custom_02": 18,
         "custom_03": 19,
@@ -40,20 +40,20 @@ midi_control_to_ksem_custom_bank_selection = bidict(
 type MidiControlTarget = Literal[
     "m01_modulation",
     "m02_breath",
-    "m04_foot",
-    "m05_portamento",
+    "m04_foot_pedal",
+    "m05_portamento_time",
     "m07_volume",
     "m10_pan",
     "m11_expression",
-    "m64_hold",
-    "m65_portamento",
-    "m66_sostenuto",
-    "m67_soft",
-    "m68_legato",
+    "m64_hold_pedal",
+    "m65_portamento_on_off",
+    "m66_sostenuto_pedal",
+    "m67_soft_pedal",
+    "m68_legato_pedal",
     "m71_resonance",
-    "m74_frequency",
-    "m91_reverb",
-    "m93_chorus",
+    "m74_frequency_cutoff",
+    "m91_reverb_level",
+    "m93_chorus_level",
     "custom_01",
     "custom_02",
     "custom_03",
@@ -95,62 +95,18 @@ class CustomBank(BaseModel):
         cfg = config["customBank"]
         return CustomBank(
             custom_bank_visible=bool(cfg["showHideCustomBank"]),
-            knob_01=CustomBankKnob(
-                name=cfg["label"]["ctrl1"],
-                control_target=cast(
-                    MidiControlTarget,
-                    midi_control_to_ksem_custom_bank_selection.inv[cfg["ctrl1_menu"]],
-                ),
-            ),
-            knob_02=CustomBankKnob(
-                name=cfg["label"]["ctrl2"],
-                control_target=cast(
-                    MidiControlTarget,
-                    midi_control_to_ksem_custom_bank_selection.inv[cfg["ctrl2_menu"]],
-                ),
-            ),
-            knob_03=CustomBankKnob(
-                name=cfg["label"]["ctrl3"],
-                control_target=cast(
-                    MidiControlTarget,
-                    midi_control_to_ksem_custom_bank_selection.inv[cfg["ctrl3_menu"]],
-                ),
-            ),
-            knob_04=CustomBankKnob(
-                name=cfg["label"]["ctrl4"],
-                control_target=cast(
-                    MidiControlTarget,
-                    midi_control_to_ksem_custom_bank_selection.inv[cfg["ctrl4_menu"]],
-                ),
-            ),
-            knob_05=CustomBankKnob(
-                name=cfg["label"]["ctrl5"],
-                control_target=cast(
-                    MidiControlTarget,
-                    midi_control_to_ksem_custom_bank_selection.inv[cfg["ctrl5_menu"]],
-                ),
-            ),
-            knob_06=CustomBankKnob(
-                name=cfg["label"]["ctrl6"],
-                control_target=cast(
-                    MidiControlTarget,
-                    midi_control_to_ksem_custom_bank_selection.inv[cfg["ctrl6_menu"]],
-                ),
-            ),
-            knob_07=CustomBankKnob(
-                name=cfg["label"]["ctrl7"],
-                control_target=cast(
-                    MidiControlTarget,
-                    midi_control_to_ksem_custom_bank_selection.inv[cfg["ctrl7_menu"]],
-                ),
-            ),
-            knob_08=CustomBankKnob(
-                name=cfg["label"]["ctrl8"],
-                control_target=cast(
-                    MidiControlTarget,
-                    midi_control_to_ksem_custom_bank_selection.inv[cfg["ctrl8_menu"]],
-                ),
-            ),
+            **{
+                f"knob_{i:02d}": CustomBankKnob(
+                    name=cast(str, cfg["label"][f"ctrl{1}"]),
+                    control_target=cast(
+                        MidiControlTarget,
+                        midi_control_to_ksem_custom_bank_selection.inv[
+                            cfg[f"ctrl{i}_menu"]
+                        ],
+                    ),
+                )
+                for i in range(1, 9)
+            },
         )
 
     def to_ksem_config(self) -> KsemCustomBank:

--- a/ksem_transformer/models/settings/midi_controls.py
+++ b/ksem_transformer/models/settings/midi_controls.py
@@ -11,20 +11,20 @@ from ksem_transformer.models.ksem_json_types import KsemConfig, KsemMidiControls
 midi_control_to_ksem = {
     "m01_modulation": "01Modulation",
     "m02_breath": "02Breath",
-    "m04_foot": "04FootPedal",
-    "m05_portamento": "05PortamentoTime",
+    "m04_foot_pedal": "04FootPedal",
+    "m05_portamento_time": "05PortamentoTime",
     "m07_volume": "07Volume",
     "m10_pan": "10Pan",
     "m11_expression": "11Expression",
-    "m64_hold": "64HoldPedal",
-    "m65_portamento": "65PortamentoOnOff",
-    "m66_sostenuto": "66SostenutoPedal",
-    "m67_soft": "67SoftPedal",
-    "m68_legato": "68LegatoPedal",
+    "m64_hold_pedal": "64HoldPedal",
+    "m65_portamento_on_off": "65PortamentoOnOff",
+    "m66_sostenuto_pedal": "66SostenutoPedal",
+    "m67_soft_pedal": "67SoftPedal",
+    "m68_legato_pedal": "68LegatoPedal",
     "m71_resonance": "71Resonance",
-    "m74_frequency": "74FrequencyCutoff",
-    "m91_reverb": "91ReverbLevel",
-    "m93_chorus": "93ChorusLevel",
+    "m74_frequency_cutoff": "74FrequencyCutoff",
+    "m91_reverb_level": "91ReverbLevel",
+    "m93_chorus_level": "93ChorusLevel",
     "custom_01": "CcCustom01",
     "custom_02": "CcCustom02",
     "custom_03": "CcCustom03",
@@ -166,20 +166,20 @@ class MidiControls(BaseModel):
 
     m01_modulation: MidiControl = Field(default_factory=MidiControl)
     m02_breath: MidiControl = Field(default_factory=MidiControl)
-    m04_foot: MidiControl = Field(default_factory=MidiControl)
-    m05_portamento: MidiControl = Field(default_factory=MidiControl)
+    m04_foot_pedal: MidiControl = Field(default_factory=MidiControl)
+    m05_portamento_time: MidiControl = Field(default_factory=MidiControl)
     m07_volume: MidiControl = Field(default_factory=MidiControl)
     m10_pan: MidiControl = Field(default_factory=MidiControl)
     m11_expression: MidiControl = Field(default_factory=MidiControl)
-    m64_hold: MidiControl = Field(default_factory=MidiControl)
-    m65_portamento: MidiControl = Field(default_factory=MidiControl)
-    m66_sostenuto: MidiControl = Field(default_factory=MidiControl)
-    m67_soft: MidiControl = Field(default_factory=MidiControl)
-    m68_legato: MidiControl = Field(default_factory=MidiControl)
+    m64_hold_pedal: MidiControl = Field(default_factory=MidiControl)
+    m65_portamento_on_off: MidiControl = Field(default_factory=MidiControl)
+    m66_sostenuto_pedal: MidiControl = Field(default_factory=MidiControl)
+    m67_soft_pedal: MidiControl = Field(default_factory=MidiControl)
+    m68_legato_pedal: MidiControl = Field(default_factory=MidiControl)
     m71_resonance: MidiControl = Field(default_factory=MidiControl)
-    m74_frequency: MidiControl = Field(default_factory=MidiControl)
-    m91_reverb: MidiControl = Field(default_factory=MidiControl)
-    m93_chorus: MidiControl = Field(default_factory=MidiControl)
+    m74_frequency_cutoff: MidiControl = Field(default_factory=MidiControl)
+    m91_reverb_level: MidiControl = Field(default_factory=MidiControl)
+    m93_chorus_level: MidiControl = Field(default_factory=MidiControl)
 
     custom_01: CustomMidiControl = Field(default_factory=CustomMidiControl)
     custom_02: CustomMidiControl = Field(default_factory=CustomMidiControl)
@@ -200,10 +200,10 @@ class MidiControls(BaseModel):
             m02_breath=MidiControl(
                 enabled=bool(cfg["02Breath_button"]), value=cfg["02Breath_dial"]
             ),
-            m04_foot=MidiControl(
+            m04_foot_pedal=MidiControl(
                 enabled=bool(cfg["04FootPedal_button"]), value=cfg["04FootPedal_dial"]
             ),
-            m05_portamento=MidiControl(
+            m05_portamento_time=MidiControl(
                 enabled=bool(cfg["05PortamentoTime_button"]),
                 value=cfg["05PortamentoTime_dial"],
             ),
@@ -216,36 +216,36 @@ class MidiControls(BaseModel):
             m11_expression=MidiControl(
                 enabled=bool(cfg["11Expression_button"]), value=cfg["11Expression_dial"]
             ),
-            m64_hold=MidiControl(
+            m64_hold_pedal=MidiControl(
                 enabled=bool(cfg["64HoldPedal_button"]), value=cfg["64HoldPedal_dial"]
             ),
-            m65_portamento=MidiControl(
+            m65_portamento_on_off=MidiControl(
                 enabled=bool(cfg["65PortamentoOnOff_button"]),
                 value=cfg["65PortamentoOnOff_dial"],
             ),
-            m66_sostenuto=MidiControl(
+            m66_sostenuto_pedal=MidiControl(
                 enabled=bool(cfg["66SostenutoPedal_button"]),
                 value=cfg["66SostenutoPedal_dial"],
             ),
-            m67_soft=MidiControl(
+            m67_soft_pedal=MidiControl(
                 enabled=bool(cfg["67SoftPedal_button"]), value=cfg["67SoftPedal_dial"]
             ),
-            m68_legato=MidiControl(
+            m68_legato_pedal=MidiControl(
                 enabled=bool(cfg["68LegatoPedal_button"]),
                 value=cfg["68LegatoPedal_dial"],
             ),
             m71_resonance=MidiControl(
                 enabled=bool(cfg["71Resonance_button"]), value=cfg["71Resonance_dial"]
             ),
-            m74_frequency=MidiControl(
+            m74_frequency_cutoff=MidiControl(
                 enabled=bool(cfg["74FrequencyCutoff_button"]),
                 value=cfg["74FrequencyCutoff_dial"],
             ),
-            m91_reverb=MidiControl(
+            m91_reverb_level=MidiControl(
                 enabled=bool(cfg["91ReverbLevel_button"]),
                 value=cfg["91ReverbLevel_dial"],
             ),
-            m93_chorus=MidiControl(
+            m93_chorus_level=MidiControl(
                 enabled=bool(cfg["93ChorusLevel_button"]),
                 value=cfg["93ChorusLevel_dial"],
             ),


### PR DESCRIPTION
Closes #7. This was a mistake on my part. I shortened them too much and it made them obtuse.

BREAKING CHANGE: Renamed MIDI controls to more closely match the names in KSEM configs.